### PR TITLE
Target cache

### DIFF
--- a/src/flow.rs
+++ b/src/flow.rs
@@ -1,7 +1,7 @@
 use crate::map::*;
 
 /// returns relative coordinates of adjacent fields within a certain range
-pub fn circle(range: usize) -> Vec<(isize, isize)> {
+fn circle(range: usize) -> Vec<(isize, isize)> {
     let mut positions = Vec::with_capacity(range * range);
 
     let range = range as isize;
@@ -17,11 +17,30 @@ pub fn circle(range: usize) -> Vec<(isize, isize)> {
     positions
 }
 
+/// finds the flow target for each position on the map and returns them in a `Vec`
+pub fn find_targets(map: &Map, range: usize) -> Vec<Vec<(usize, usize)>> {
+    let (width, height) = (map.width(), map.height());
+    let mut targets = vec![vec![(0, 0); height]; width];
+    let at_border = |x, y| x < range || x >= width - range || y < range || y >= height - range;
+    let circle = circle(range);
+
+    for x in 0..width {
+        for y in 0..height {
+            if at_border(x, y) {
+                targets[x][y] = (x, y);
+            } else {
+                targets[x][y] = next_target(map, x, y, &circle);
+            }
+        }
+    }
+    targets
+}
+
 /// Finds the lowest neighbor around a point on the map using the relative coordinates of all
 /// neighbors.
 /// Relative coordinates of all neighbors can be found once using the [`circle`](./fn.circle.html) function.
 #[inline]
-pub fn next_target(
+fn next_target(
     map: &Map,
     x: usize,
     y: usize,

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -1,39 +1,88 @@
 use crate::map::*;
 
-/// returns relative coordinates of adjacent fields within a certain range
-fn circle(range: usize) -> Vec<(isize, isize)> {
-    let mut positions = Vec::with_capacity(range * range);
+/// finds the flow target for each position on the map and returns them in a `Vec`
+pub fn find_targets(map: &Map, range: usize) -> Vec<Vec<(usize, usize)>> {
+    assert!(range >= 1);
 
+    let (width, height) = (map.width(), map.height());
+    let mut targets = vec![vec![(0, 0); height]; width];
+
+    let at_border = |x, y| x < range || x >= width - range || y < range || y >= height - range;
+    let circle = |x, y| x * x + y * y < (range * range) as isize;
+    let within_range = |x, y, (ox, oy)| circle(x as isize - ox as isize, y as isize - oy as isize);
+
+    // points to check that neighbors didn't check with 4 different cases
+    let rest_points = [
+        points(range, &circle),
+        points(range, &|x, y| circle(x, y) && !circle(x + 1, y)),
+        points(range, &|x, y| circle(x, y) && !circle(x, y + 1)),
+        points(range, &|x, y| {
+            circle(x, y) && !circle(x + 1, y) && !circle(x, y + 1)
+        }),
+    ];
+
+    for x in 0..width {
+        for y in 0..height {
+            if at_border(x, y) {
+                let points = points(range, &|nx, ny| {
+                    let (x, y, w, h) = (x as isize, y as isize, width as isize, height as isize);
+                    nx >= -x && ny >= -y && x + nx < w && y + ny < h && circle(nx, ny)
+                });
+                targets[x][y] = next_target(map, x, y, &points);
+            } else {
+                let mut lowest = f32::MAX;
+                let mut target = (x, y);
+                let mut rest_idx = 0;
+
+                // check if target of x neighbor can be used
+                let tx = targets[x - 1][y];
+                if within_range(x, y, tx) {
+                    rest_idx += 1;
+                    lowest = map[tx];
+                    target = tx;
+                }
+
+                // check if target of y neighbor can be used
+                let ty = targets[x][y - 1];
+                if within_range(x, y, ty) {
+                    rest_idx += 2;
+                    let h = map[ty];
+                    if h < lowest {
+                        lowest = h;
+                        target = ty;
+                    }
+                }
+
+                // check if there is a better minimum in the points
+                // the previous neighbors didn't reach but this point does
+                let t = next_target(map, x, y, &rest_points[rest_idx]);
+                let h = map[t];
+                if h < lowest {
+                    target = t;
+                }
+
+                targets[x][y] = target;
+            }
+        }
+    }
+
+    targets
+}
+
+/// Finds points within a range that satisfy a property
+fn points(range: usize, inside: &dyn Fn(isize, isize) -> bool) -> Vec<(isize, isize)> {
+    let mut positions = Vec::with_capacity(range * range);
     let range = range as isize;
 
     for x in (-range)..=(range) {
         for y in (-range)..=(range) {
-            if x * x + y * y <= range * range {
+            if inside(x, y) {
                 positions.push((x, y));
             }
         }
     }
 
     positions
-}
-
-/// finds the flow target for each position on the map and returns them in a `Vec`
-pub fn find_targets(map: &Map, range: usize) -> Vec<Vec<(usize, usize)>> {
-    let (width, height) = (map.width(), map.height());
-    let mut targets = vec![vec![(0, 0); height]; width];
-    let at_border = |x, y| x < range || x >= width - range || y < range || y >= height - range;
-    let circle = circle(range);
-
-    for x in 0..width {
-        for y in 0..height {
-            if at_border(x, y) {
-                targets[x][y] = (x, y);
-            } else {
-                targets[x][y] = next_target(map, x, y, &circle);
-            }
-        }
-    }
-    targets
 }
 
 /// Finds the lowest neighbor around a point on the map using the relative coordinates of all
@@ -47,7 +96,7 @@ fn next_target(
     neighbor_positions: &[(isize, isize)],
 ) -> (usize, usize) {
     let (mut nx, mut ny) = (x, y); // next x,y
-    let mut lowest = std::f32::MAX; // lowest z coordinate of neighbors
+    let mut lowest = f32::MAX; // lowest z coordinate of neighbors
 
     let (x, y) = (x as isize, y as isize);
 
@@ -123,4 +172,28 @@ pub fn draw_line(
     }
 
     map[(x as _, y as _)] = fun(map[(x as _, y as _)]);
+}
+
+/// Check if the efficient DP solution does find the local minimum of each point correctly
+#[test]
+fn check_dp_solution() {
+    use crate::simplex::*;
+
+    let size = 128;
+    let map = simplex_map(size, size);
+    let range = 6;
+    let targets = find_targets(&map, range);
+    let circle = |x, y| x * x + y * y < (range * range) as isize;
+    let points = points(range, &circle);
+
+    for x in range..(size - range) {
+        for y in range..(size - range) {
+            let target = next_target(&map, x, y, &points);
+
+            // Check if found _a_ minimum, not the specific minimum the target function would have
+            // found. If the height is the same, but the coordinates are different, there are
+            // multiple valid solutions.
+            assert_eq!(map[target], map[targets[x][y]]);
+        }
+    }
 }

--- a/src/lake.rs
+++ b/src/lake.rs
@@ -1,11 +1,15 @@
-use crate::{flow::*, map::*};
+use crate::map::*;
 use std::collections::*;
 
-pub fn lake_map(map: &Map, rivers: &Map, ocean: f32, range: usize) -> Map {
+pub fn lake_map(
+    map: &Map,
+    rivers: &Map,
+    cell_targets: &Vec<Vec<(usize, usize)>>,
+    ocean: f32,
+    range: usize,
+) -> Map {
     let width = map.width();
     let height = map.height();
-
-    let circle = circle(range);
 
     let mut lake_origins = Vec::new();
     let mut lakes = Map::new(width, height);
@@ -19,7 +23,7 @@ pub fn lake_map(map: &Map, rivers: &Map, ocean: f32, range: usize) -> Map {
 
             if z < ocean || at_border(x, y) {
                 lakes[xy] = 1.0;
-            } else if xy == next_target(map, x, y, &circle) && rivers[xy] > 100.0 {
+            } else if xy == cell_targets[x][y] && rivers[xy] > 100.0 {
                 lake_origins.push(Point { x, y, z });
             }
         }
@@ -54,7 +58,7 @@ pub fn lake_map(map: &Map, rivers: &Map, ocean: f32, range: usize) -> Map {
                 break;
             }
 
-            let (nx, ny) = next_target(map, x, y, &circle);
+            let (nx, ny) = cell_targets[x][y];
             if enq!(x - 1, y) || enq!(x + 1, y) || enq!(x, y - 1) || enq!(x, y + 1) || enq!(nx, ny)
             {
                 break;

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,11 +23,14 @@ fn main() -> std::io::Result<()> {
     let map = log("Generating Simplex Map", || {
         simplex::simplex_map(size, size)
     });
+    let targets = log("Finding Flow Targets", || {
+        flow::find_targets(&map, water_range)
+    });
     let mut river_map = log("Generating River Map", || {
-        river::create_flow_map(&map, water_range)
+        river::create_flow_map(&map, &targets, water_range)
     });
     let lake_map = log("Generating Lake Map", || {
-        lake::lake_map(&map, &river_map, ocean_height, water_range)
+        lake::lake_map(&map, &river_map, &targets, ocean_height, water_range)
     });
 
     log("Adjusting River Map", || river_map.map(|h| h.powf(0.45)));

--- a/src/river.rs
+++ b/src/river.rs
@@ -5,11 +5,10 @@ use crate::{flow::*, map::*};
 /// It does so by distributing water on each cell of the map and drawing
 /// all of the waters path onto the flow_map, which it returns.
 ///
-pub fn create_flow_map(map: &Map, range: usize) -> Map {
+pub fn create_flow_map(map: &Map, cell_targets: &Vec<Vec<(usize, usize)>>, range: usize) -> Map {
     let width = map.width();
     let height = map.height();
     let mut flow_map = Map::new(width, height);
-    let circle = circle(range);
 
     assert!(range < (1 << 13));
 
@@ -21,7 +20,7 @@ pub fn create_flow_map(map: &Map, range: usize) -> Map {
     // finding how many times each cell is targeted
     for x in range..(width - range) {
         for y in range..(height - range) {
-            let (nx, ny) = next_target(map, x, y, &circle);
+            let (nx, ny) = cell_targets[x][y];
             if (nx, ny) != (x, y) {
                 targets[nx][ny] += 1;
             }
@@ -40,7 +39,7 @@ pub fn create_flow_map(map: &Map, range: usize) -> Map {
                         break;
                     }
 
-                    let (nx, ny) = next_target(map, x, y, &circle);
+                    let (nx, ny) = cell_targets[x][y];
 
                     draw_line(&mut flow_map, x as _, y as _, nx as _, ny as _, &|h| {
                         h + volume[x][y]


### PR DESCRIPTION
optimization to minimize calls to `next_target`
previously the river map generation and lake map generation all called `next_target`
Now there are at most width*height calls to `next_target`, as it is precomputed in `find_targets`.